### PR TITLE
Fix for Plex Token and PadStart

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ I just wanted to do something pretty straightforward, so here it is.
 ## Dev Setup
 
 - `npm install`
-- rename `config/secrets_template.js` to `config/secrets.js` and configure
+- rename `config/secrets_template.js` to `config/secrets.js` and configure ([How do I get my Plex token?](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/))
 - `npm run start`
 
 ## Run on Startup - Linux + PM2

--- a/config/secrets_template.js
+++ b/config/secrets_template.js
@@ -7,6 +7,7 @@ const secrets = {
   plex:{
     host: '192.168.10.1',
     port: '32400',
+	  token: 'PLEX_TOKEN',
   },
 };
 

--- a/src/rpc/client.js
+++ b/src/rpc/client.js
@@ -11,8 +11,10 @@ const secrets = require('../../config/secrets');
 
 
 function buildEpisodeString(session){
-  const title = session.episode.title;
-  return `S${session.season.padStart(2,'0')}E${session.episode.index.padStart(3,'0')} - ${title}`
+  const title = session.episode.title.toString();
+  const season = session.season.toString();
+  const episodeIndex = session.episode.index.toString();
+  return `S${season.padStart(2,'0')}E${episodeIndex.padStart(2,'0')} - ${title}`
 }
 
 async function buildRpcData(session){
@@ -48,7 +50,7 @@ async function buildRpcData(session){
 
 async function update(){
   try{
-    const session = await Plex.getPlexSession(secrets.plex.host, secrets.plex.port);
+    const session = await Plex.getPlexSession(secrets.plex.host, secrets.plex.port, secrets.plex.token);
     if(session !== ''){
       const rpcData = await buildRpcData(session);
       client.setActivity(rpcData);

--- a/src/rpc/plex.js
+++ b/src/rpc/plex.js
@@ -18,8 +18,8 @@ function getRelevantData(session){
   }
 }
 
-async function getPlexSession(host, port){
-  const resp = await axios.get(`http://${host}:${port}/status/sessions`);
+async function getPlexSession(host, port, token){
+  const resp = await axios.get(`http://${host}:${port}/status/sessions?X-Plex-Token=${token}`);
 
   if(resp['status'] === 200){
     const data = resp['data'];


### PR DESCRIPTION
Fixes for things that broke/changed.
- Plex now requires you to use your Plex Token to get the current sessions. Without the Token, you get ```401 Unauthorized``` as a response. I added a Token option to the config and the parameter to ```getPlexSession()```.
- padStart throws the error ```padStart is not a function``` and it seems like this happens when the values aren't strings (like the season and index). I added 2 variables and convert them to strings to fix this issue.
- changed the episode Index padStart from ```3``` to ```2```, probably just my preference but having only one leading zero looks cleaner imo.
- Added a hyperlink to the Readme to the Plex article on how to obtain your Plex Token.